### PR TITLE
trigger names need to be consistent

### DIFF
--- a/actions/create_tpr_sensor.py
+++ b/actions/create_tpr_sensor.py
@@ -42,7 +42,7 @@ class createTPRSensor(Action):
             return (False, "Couldn't match 3PR with an api endpoint")
 
         allvars['watchurl'] = "/apis/prsn.io/v1/watch/" + pname
-        allvars['triggername'] = "thirdpartyobject"
+        allvars['triggername'] = "thirdpartyresources"
         allvars['operationId'] = "watch" + cname
 
         sensorpy = self.config['template_path'] + "/sensors/" + allvars['operationId'] + ".py"

--- a/etc/st2packgen/files/actions/create_tpr_sensor.py
+++ b/etc/st2packgen/files/actions/create_tpr_sensor.py
@@ -42,7 +42,7 @@ class createTPRSensor(Action):
             return (False, "Couldn't match 3PR with an api endpoint")
 
         allvars['watchurl'] = "/apis/prsn.io/v1/watch/" + pname
-        allvars['triggername'] = "thirdpartyobject"
+        allvars['triggername'] = "thirdpartyresources"
         allvars['operationId'] = "watch" + cname
 
         sensorpy = self.config['template_path'] + "/sensors/" + allvars['operationId'] + ".py"


### PR DESCRIPTION
rename trigger name within create_tpr_sensor to be consistent with other third party resource trigger names