### PR TITLE
Fixed #28: Avoid empty strings in config files to be used as valid ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ template_path: "/opt/stackstorm/packs/kubernetes/"
 ```
 Where kubernetes_api_url = The FQDN to your Kubernetes API endpoint.
 
-Only user and password or client_cert_path (key is optional) need to be set for this to work
+Only `user` and `password` or `client_cert_path` (`client_cert_key_path` is optional) need to be set for this to work. It means you should remove `user` and `password` fields from the `kubernetes.yaml` config file if you are using a certificate.
 
-Note: Currently SSL verification is turned off. This is a WIP.
+> Note: Currently SSL verification is turned off. This is a WIP.
 
 All actions allow an optional 'config_override' argument which takes an object with any of the above
 example:

--- a/actions/lib/k8s.py
+++ b/actions/lib/k8s.py
@@ -33,12 +33,16 @@ class K8sClient(Action):
             if self.myconfig[entry] == 'None':
                 self.myconfig[entry] = None
 
-        if 'user' in self.myconfig and self.myconfig['user'] is not None and self.myconfig['user']:
+        if ('user' in self.myconfig and 
+            self.myconfig['user'] is not None and 
+            self.myconfig['user']):
             if 'password' in self.myconfig and self.myconfig['password'] is not None:
                 self.addauth()
             else:
                 return (False, "user defined but no password")
-        elif 'client_cert_path' in self.myconfig and self.myconfig['client_cert_path'] is not None and self.myconfig['client_cert_path']:
+        elif ('client_cert_path' in self.myconfig and 
+            self.myconfig['client_cert_path'] is not None and 
+            self.myconfig['client_cert_path']):
             self.clientcert = 1
             return True
         else:

--- a/actions/lib/k8s.py
+++ b/actions/lib/k8s.py
@@ -33,12 +33,12 @@ class K8sClient(Action):
             if self.myconfig[entry] == 'None':
                 self.myconfig[entry] = None
 
-        if 'user' in self.myconfig and self.myconfig['user'] is not None:
+        if 'user' in self.myconfig and self.myconfig['user'] is not None and self.myconfig['user']:
             if 'password' in self.myconfig and self.myconfig['password'] is not None:
                 self.addauth()
             else:
                 return (False, "user defined but no password")
-        elif 'client_cert_path' in self.myconfig and self.myconfig['client_cert_path'] is not None:
+        elif 'client_cert_path' in self.myconfig and self.myconfig['client_cert_path'] is not None and self.myconfig['client_cert_path']:
             self.clientcert = 1
             return True
         else:

--- a/actions/lib/k8s.py
+++ b/actions/lib/k8s.py
@@ -33,16 +33,16 @@ class K8sClient(Action):
             if self.myconfig[entry] == 'None':
                 self.myconfig[entry] = None
 
-        if ('user' in self.myconfig and 
-            self.myconfig['user'] is not None and 
-            self.myconfig['user']):
+        if ('user' in self.myconfig and
+                self.myconfig['user'] is not None and
+                self.myconfig['user']):
             if 'password' in self.myconfig and self.myconfig['password'] is not None:
                 self.addauth()
             else:
                 return (False, "user defined but no password")
-        elif ('client_cert_path' in self.myconfig and 
-            self.myconfig['client_cert_path'] is not None and 
-            self.myconfig['client_cert_path']):
+        elif ('client_cert_path' in self.myconfig and
+                self.myconfig['client_cert_path'] is not None and
+                self.myconfig['client_cert_path']):
             self.clientcert = 1
             return True
         else:


### PR DESCRIPTION
I strengthened the if conditions to check also for not empty string. In Python empty string are _"falsy"_, so checking for a string to be True means it is not empty.

I also updated the README in order to clarify the config file fields, even though the code should be enough conservative now.