### PR TITLE
Update pyopenssl version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.9.8
+
+- Upgrade pyopenssl to resolve security vulnerabilities
+
 ## 0.9.7
 
 - Fixed issue with use of certs for authentication

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - kubernetes
   - sensors
   - thirdpartyresource
-version: 0.9.7
+version: 0.9.8
 author: Andrew Moore
 email: andy@impulsed.net
 contributors:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyswagger
 jinja2
 http_parser
 backports.ssl==0.0.9
-pyopenssl==16.2.0
+pyopenssl==17.5.0


### PR DESCRIPTION
Older pyopenssl version has security issues. Any reason we should not upgrade to this?