### PR TITLE
Add bearer token config field to config schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.9.10
+- Add schema documentation for bearer token authentication support
+
 ## 0.9.9
 
 - Added bearer token authentication support

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -16,6 +16,9 @@
   client_cert_key_path:
     description: "client cert key path"
     type: "string"
+  bearer_token:
+    description: "bearer token"
+    type: "string"
   verify:
     description: "SSL verify"
     type: "boolean"

--- a/etc/st2packgen/files/config.schema.yaml
+++ b/etc/st2packgen/files/config.schema.yaml
@@ -17,6 +17,9 @@
   client_cert_key_path:
     description: "client cert key path"
     type: "string"
+  bearer_token:
+    description: "bearer token"
+    type: "string"
   verify:
     description: "SSL verify"
     type: "boolean"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - kubernetes
   - sensors
   - thirdpartyresource
-version: 0.9.9
+version: 0.9.10
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
In https://github.com/StackStorm-Exchange/stackstorm-kubernetes/pull/34, I forgot to add the `bearer_token` in the `config.schema.yaml`.  This adds it.