### PR TITLE
Fix query parameters handling on API requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.9.11
+- Fix issue with improper API address resolution
+- Add port support
+
 ## 0.9.10
 - Add schema documentation for bearer token authentication support
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.9.12
+- Add resolution for query parameters on making API requests
+- Add fallback for JSON decoding on API responses
+
 ## 0.9.11
 - Fix issue with improper API address resolution
 - Add port support

--- a/actions/createAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/createAppsV1beta1NamespacedStatefulSet.py
@@ -16,7 +16,7 @@ class createAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createAuthenticationV1beta1TokenReview.py
+++ b/actions/createAuthenticationV1beta1TokenReview.py
@@ -15,7 +15,7 @@ class createAuthenticationV1beta1TokenReview(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createAuthenticationV1beta1TokenReview(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authentication.k8s.io/v1beta1/tokenreviews".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createAuthenticationV1beta1TokenReview(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createAuthorizationV1beta1NamespacedLocalSubjectAccessReview.py
+++ b/actions/createAuthorizationV1beta1NamespacedLocalSubjectAccessReview.py
@@ -16,7 +16,7 @@ class createAuthorizationV1beta1NamespacedLocalSubjectAccessReview(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createAuthorizationV1beta1NamespacedLocalSubjectAccessReview(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authorization.k8s.io/v1beta1/namespaces/{namespace}/localsubjectaccessreviews".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createAuthorizationV1beta1NamespacedLocalSubjectAccessReview(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createAuthorizationV1beta1SelfSubjectAccessReview.py
+++ b/actions/createAuthorizationV1beta1SelfSubjectAccessReview.py
@@ -15,7 +15,7 @@ class createAuthorizationV1beta1SelfSubjectAccessReview(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createAuthorizationV1beta1SelfSubjectAccessReview(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authorization.k8s.io/v1beta1/selfsubjectaccessreviews".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createAuthorizationV1beta1SelfSubjectAccessReview(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createAuthorizationV1beta1SubjectAccessReview.py
+++ b/actions/createAuthorizationV1beta1SubjectAccessReview.py
@@ -15,7 +15,7 @@ class createAuthorizationV1beta1SubjectAccessReview(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createAuthorizationV1beta1SubjectAccessReview(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authorization.k8s.io/v1beta1/subjectaccessreviews".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createAuthorizationV1beta1SubjectAccessReview(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/createAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -16,7 +16,7 @@ class createAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createBatchV1NamespacedJob.py
+++ b/actions/createBatchV1NamespacedJob.py
@@ -16,7 +16,7 @@ class createBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/createCertificatesV1alpha1CertificateSigningRequest.py
@@ -15,7 +15,7 @@ class createCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createCertificatesV1alpha1CertificateSigningRequest(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1Namespace.py
+++ b/actions/createCoreV1Namespace.py
@@ -15,7 +15,7 @@ class createCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createCoreV1Namespace(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedBinding.py
+++ b/actions/createCoreV1NamespacedBinding.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/bindings".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedBindingBinding.py
+++ b/actions/createCoreV1NamespacedBindingBinding.py
@@ -17,7 +17,7 @@ class createCoreV1NamespacedBindingBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class createCoreV1NamespacedBindingBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/binding".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class createCoreV1NamespacedBindingBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedConfigMap.py
+++ b/actions/createCoreV1NamespacedConfigMap.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedEndpoints.py
+++ b/actions/createCoreV1NamespacedEndpoints.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedEvent.py
+++ b/actions/createCoreV1NamespacedEvent.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedEvictionEviction.py
+++ b/actions/createCoreV1NamespacedEvictionEviction.py
@@ -17,7 +17,7 @@ class createCoreV1NamespacedEvictionEviction(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class createCoreV1NamespacedEvictionEviction(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/eviction".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class createCoreV1NamespacedEvictionEviction(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedLimitRange.py
+++ b/actions/createCoreV1NamespacedLimitRange.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/createCoreV1NamespacedPersistentVolumeClaim.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedPod.py
+++ b/actions/createCoreV1NamespacedPod.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedPodTemplate.py
+++ b/actions/createCoreV1NamespacedPodTemplate.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedReplicationController.py
+++ b/actions/createCoreV1NamespacedReplicationController.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedResourceQuota.py
+++ b/actions/createCoreV1NamespacedResourceQuota.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedSecret.py
+++ b/actions/createCoreV1NamespacedSecret.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedService.py
+++ b/actions/createCoreV1NamespacedService.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1NamespacedServiceAccount.py
+++ b/actions/createCoreV1NamespacedServiceAccount.py
@@ -16,7 +16,7 @@ class createCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1Node.py
+++ b/actions/createCoreV1Node.py
@@ -15,7 +15,7 @@ class createCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createCoreV1Node(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createCoreV1PersistentVolume.py
+++ b/actions/createCoreV1PersistentVolume.py
@@ -15,7 +15,7 @@ class createCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createCoreV1PersistentVolume(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/createExtensionsV1beta1NamespacedDaemonSet.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/createExtensionsV1beta1NamespacedDeployment.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedDeploymentRollbackRollback.py
+++ b/actions/createExtensionsV1beta1NamespacedDeploymentRollbackRollback.py
@@ -17,7 +17,7 @@ class createExtensionsV1beta1NamespacedDeploymentRollbackRollback(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class createExtensionsV1beta1NamespacedDeploymentRollbackRollback(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/rollback".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class createExtensionsV1beta1NamespacedDeploymentRollbackRollback(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/createExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedIngress.py
+++ b/actions/createExtensionsV1beta1NamespacedIngress.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedJob.py
+++ b/actions/createExtensionsV1beta1NamespacedJob.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/createExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/createExtensionsV1beta1NamespacedReplicaSet.py
@@ -16,7 +16,7 @@ class createExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/createExtensionsV1beta1ThirdPartyResource.py
@@ -15,7 +15,7 @@ class createExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createExtensionsV1beta1ThirdPartyResource(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createPolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/createPolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -16,7 +16,7 @@ class createPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/createRbacAuthorizationV1alpha1ClusterRole.py
@@ -15,7 +15,7 @@ class createRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createRbacAuthorizationV1alpha1ClusterRole(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/createRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -15,7 +15,7 @@ class createRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/createRbacAuthorizationV1alpha1NamespacedRole.py
@@ -16,7 +16,7 @@ class createRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/createRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -16,7 +16,7 @@ class createRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class createRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".format(  # noqa pylint: disable=line-too-long
             body=body, namespace=namespace)
@@ -43,7 +44,10 @@ class createRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/createStorageV1beta1StorageClass.py
+++ b/actions/createStorageV1beta1StorageClass.py
@@ -15,7 +15,7 @@ class createStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class createStorageV1beta1StorageClass(K8sClient):
         else:
             return (False, "body is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses".format(  # noqa pylint: disable=line-too-long
             body=body)
@@ -38,7 +39,10 @@ class createStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteAppsV1beta1CollectionNamespacedStatefulSet.py
+++ b/actions/deleteAppsV1beta1CollectionNamespacedStatefulSet.py
@@ -20,7 +20,7 @@ class deleteAppsV1beta1CollectionNamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteAppsV1beta1CollectionNamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteAppsV1beta1CollectionNamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/deleteAppsV1beta1NamespacedStatefulSet.py
@@ -19,7 +19,7 @@ class deleteAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler.py
+++ b/actions/deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler.py
@@ -20,7 +20,7 @@ class deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteAutoscalingV1CollectionNamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/deleteAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -19,7 +19,7 @@ class deleteAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteBatchV1CollectionNamespacedJob.py
+++ b/actions/deleteBatchV1CollectionNamespacedJob.py
@@ -20,7 +20,7 @@ class deleteBatchV1CollectionNamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteBatchV1CollectionNamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteBatchV1CollectionNamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteBatchV1NamespacedJob.py
+++ b/actions/deleteBatchV1NamespacedJob.py
@@ -19,7 +19,7 @@ class deleteBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/deleteCertificatesV1alpha1CertificateSigningRequest.py
@@ -18,7 +18,7 @@ class deleteCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteCertificatesV1alpha1CertificateSigningRequest(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCertificatesV1alpha1CollectionCertificateSigningRequest.py
+++ b/actions/deleteCertificatesV1alpha1CollectionCertificateSigningRequest.py
@@ -19,25 +19,26 @@ class deleteCertificatesV1alpha1CollectionCertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteCertificatesV1alpha1CollectionCertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespace.py
+++ b/actions/deleteCoreV1CollectionNamespace.py
@@ -19,25 +19,26 @@ class deleteCoreV1CollectionNamespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteCoreV1CollectionNamespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedConfigMap.py
+++ b/actions/deleteCoreV1CollectionNamespacedConfigMap.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedEndpoints.py
+++ b/actions/deleteCoreV1CollectionNamespacedEndpoints.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedEvent.py
+++ b/actions/deleteCoreV1CollectionNamespacedEvent.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedLimitRange.py
+++ b/actions/deleteCoreV1CollectionNamespacedLimitRange.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedPersistentVolumeClaim.py
+++ b/actions/deleteCoreV1CollectionNamespacedPersistentVolumeClaim.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedPod.py
+++ b/actions/deleteCoreV1CollectionNamespacedPod.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedPodTemplate.py
+++ b/actions/deleteCoreV1CollectionNamespacedPodTemplate.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedReplicationController.py
+++ b/actions/deleteCoreV1CollectionNamespacedReplicationController.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedResourceQuota.py
+++ b/actions/deleteCoreV1CollectionNamespacedResourceQuota.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedSecret.py
+++ b/actions/deleteCoreV1CollectionNamespacedSecret.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNamespacedServiceAccount.py
+++ b/actions/deleteCoreV1CollectionNamespacedServiceAccount.py
@@ -20,7 +20,7 @@ class deleteCoreV1CollectionNamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteCoreV1CollectionNamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteCoreV1CollectionNamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionNode.py
+++ b/actions/deleteCoreV1CollectionNode.py
@@ -19,25 +19,26 @@ class deleteCoreV1CollectionNode(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteCoreV1CollectionNode(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1CollectionPersistentVolume.py
+++ b/actions/deleteCoreV1CollectionPersistentVolume.py
@@ -19,25 +19,26 @@ class deleteCoreV1CollectionPersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteCoreV1CollectionPersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1Namespace.py
+++ b/actions/deleteCoreV1Namespace.py
@@ -18,7 +18,7 @@ class deleteCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteCoreV1Namespace(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedConfigMap.py
+++ b/actions/deleteCoreV1NamespacedConfigMap.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedEndpoints.py
+++ b/actions/deleteCoreV1NamespacedEndpoints.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedEvent.py
+++ b/actions/deleteCoreV1NamespacedEvent.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedLimitRange.py
+++ b/actions/deleteCoreV1NamespacedLimitRange.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/deleteCoreV1NamespacedPersistentVolumeClaim.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedPod.py
+++ b/actions/deleteCoreV1NamespacedPod.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedPodTemplate.py
+++ b/actions/deleteCoreV1NamespacedPodTemplate.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedReplicationController.py
+++ b/actions/deleteCoreV1NamespacedReplicationController.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedResourceQuota.py
+++ b/actions/deleteCoreV1NamespacedResourceQuota.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedSecret.py
+++ b/actions/deleteCoreV1NamespacedSecret.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedService.py
+++ b/actions/deleteCoreV1NamespacedService.py
@@ -16,7 +16,7 @@ class deleteCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class deleteCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class deleteCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1NamespacedServiceAccount.py
+++ b/actions/deleteCoreV1NamespacedServiceAccount.py
@@ -19,7 +19,7 @@ class deleteCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1Node.py
+++ b/actions/deleteCoreV1Node.py
@@ -18,7 +18,7 @@ class deleteCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteCoreV1Node(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteCoreV1PersistentVolume.py
+++ b/actions/deleteCoreV1PersistentVolume.py
@@ -18,7 +18,7 @@ class deleteCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteCoreV1PersistentVolume(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedDaemonSet.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedDaemonSet.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedDeployment.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedDeployment.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedHorizontalPodAutoscaler.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedHorizontalPodAutoscaler.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedHorizontalPodAutoscaler(K8sClie
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedHorizontalPodAutoscaler(K8sClie
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedHorizontalPodAutoscaler(K8sClie
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedIngress.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedIngress.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedJob.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedJob.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedNetworkPolicy.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedNetworkPolicy.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionNamespacedReplicaSet.py
+++ b/actions/deleteExtensionsV1beta1CollectionNamespacedReplicaSet.py
@@ -20,7 +20,7 @@ class deleteExtensionsV1beta1CollectionNamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteExtensionsV1beta1CollectionNamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteExtensionsV1beta1CollectionNamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1CollectionThirdPartyResource.py
+++ b/actions/deleteExtensionsV1beta1CollectionThirdPartyResource.py
@@ -19,25 +19,26 @@ class deleteExtensionsV1beta1CollectionThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteExtensionsV1beta1CollectionThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/deleteExtensionsV1beta1NamespacedDaemonSet.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/deleteExtensionsV1beta1NamespacedDeployment.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/deleteExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedIngress.py
+++ b/actions/deleteExtensionsV1beta1NamespacedIngress.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedJob.py
+++ b/actions/deleteExtensionsV1beta1NamespacedJob.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/deleteExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/deleteExtensionsV1beta1NamespacedReplicaSet.py
@@ -19,7 +19,7 @@ class deleteExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/deleteExtensionsV1beta1ThirdPartyResource.py
@@ -18,7 +18,7 @@ class deleteExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteExtensionsV1beta1ThirdPartyResource(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget.py
+++ b/actions/deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget.py
@@ -20,7 +20,7 @@ class deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deletePolicyV1beta1CollectionNamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deletePolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/deletePolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -19,7 +19,7 @@ class deletePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deletePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deletePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/deleteRbacAuthorizationV1alpha1ClusterRole.py
@@ -18,7 +18,7 @@ class deleteRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteRbacAuthorizationV1alpha1ClusterRole(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/deleteRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -18,7 +18,7 @@ class deleteRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1CollectionClusterRole.py
+++ b/actions/deleteRbacAuthorizationV1alpha1CollectionClusterRole.py
@@ -19,25 +19,26 @@ class deleteRbacAuthorizationV1alpha1CollectionClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteRbacAuthorizationV1alpha1CollectionClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1CollectionClusterRoleBinding.py
+++ b/actions/deleteRbacAuthorizationV1alpha1CollectionClusterRoleBinding.py
@@ -19,25 +19,26 @@ class deleteRbacAuthorizationV1alpha1CollectionClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteRbacAuthorizationV1alpha1CollectionClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1CollectionNamespacedRole.py
+++ b/actions/deleteRbacAuthorizationV1alpha1CollectionNamespacedRole.py
@@ -20,7 +20,7 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding.py
+++ b/actions/deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding.py
@@ -20,7 +20,7 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class deleteRbacAuthorizationV1alpha1CollectionNamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/deleteRbacAuthorizationV1alpha1NamespacedRole.py
@@ -19,7 +19,7 @@ class deleteRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/deleteRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -19,7 +19,7 @@ class deleteRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -37,13 +37,14 @@ class deleteRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -54,7 +55,10 @@ class deleteRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteStorageV1beta1CollectionStorageClass.py
+++ b/actions/deleteStorageV1beta1CollectionStorageClass.py
@@ -19,25 +19,26 @@ class deleteStorageV1beta1CollectionStorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class deleteStorageV1beta1CollectionStorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/deleteStorageV1beta1StorageClass.py
+++ b/actions/deleteStorageV1beta1StorageClass.py
@@ -18,7 +18,7 @@ class deleteStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class deleteStorageV1beta1StorageClass(K8sClient):
         else:
             return (False, "name is a required parameter")
         if gracePeriodSeconds is not None:
-            args['gracePeriodSeconds'] = gracePeriodSeconds
+            args['params'].update({'gracePeriodSeconds': gracePeriodSeconds})
         if orphanDependents is not None:
-            args['orphanDependents'] = orphanDependents
+            args['params'].update({'orphanDependents': orphanDependents})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -49,7 +50,10 @@ class deleteStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAPIVersions.py
+++ b/actions/getAPIVersions.py
@@ -13,13 +13,14 @@ class getAPIVersions(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAPIVersions(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAppsAPIGroup.py
+++ b/actions/getAppsAPIGroup.py
@@ -13,13 +13,14 @@ class getAppsAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAppsAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAppsV1beta1APIResources.py
+++ b/actions/getAppsV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getAppsV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAppsV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAuthenticationAPIGroup.py
+++ b/actions/getAuthenticationAPIGroup.py
@@ -13,13 +13,14 @@ class getAuthenticationAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authentication.k8s.io/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAuthenticationAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAuthenticationV1beta1APIResources.py
+++ b/actions/getAuthenticationV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getAuthenticationV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authentication.k8s.io/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAuthenticationV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAuthorizationAPIGroup.py
+++ b/actions/getAuthorizationAPIGroup.py
@@ -13,13 +13,14 @@ class getAuthorizationAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authorization.k8s.io/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAuthorizationAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAuthorizationV1beta1APIResources.py
+++ b/actions/getAuthorizationV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getAuthorizationV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/authorization.k8s.io/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAuthorizationV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAutoscalingAPIGroup.py
+++ b/actions/getAutoscalingAPIGroup.py
@@ -13,13 +13,14 @@ class getAutoscalingAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAutoscalingAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getAutoscalingV1APIResources.py
+++ b/actions/getAutoscalingV1APIResources.py
@@ -13,13 +13,14 @@ class getAutoscalingV1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getAutoscalingV1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getBatchAPIGroup.py
+++ b/actions/getBatchAPIGroup.py
@@ -13,13 +13,14 @@ class getBatchAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getBatchAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getBatchV1APIResources.py
+++ b/actions/getBatchV1APIResources.py
@@ -13,13 +13,14 @@ class getBatchV1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getBatchV1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getBatchV2alpha1APIResources.py
+++ b/actions/getBatchV2alpha1APIResources.py
@@ -13,13 +13,14 @@ class getBatchV2alpha1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v2alpha1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getBatchV2alpha1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getCertificatesAPIGroup.py
+++ b/actions/getCertificatesAPIGroup.py
@@ -13,13 +13,14 @@ class getCertificatesAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getCertificatesAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getCertificatesV1alpha1APIResources.py
+++ b/actions/getCertificatesV1alpha1APIResources.py
@@ -13,13 +13,14 @@ class getCertificatesV1alpha1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getCertificatesV1alpha1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getCoreAPIVersions.py
+++ b/actions/getCoreAPIVersions.py
@@ -13,13 +13,14 @@ class getCoreAPIVersions(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getCoreAPIVersions(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getCoreV1APIResources.py
+++ b/actions/getCoreV1APIResources.py
@@ -13,13 +13,14 @@ class getCoreV1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getCoreV1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getExtensionsAPIGroup.py
+++ b/actions/getExtensionsAPIGroup.py
@@ -13,13 +13,14 @@ class getExtensionsAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getExtensionsAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getExtensionsV1beta1APIResources.py
+++ b/actions/getExtensionsV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getExtensionsV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getExtensionsV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getPolicyAPIGroup.py
+++ b/actions/getPolicyAPIGroup.py
@@ -13,13 +13,14 @@ class getPolicyAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getPolicyAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getPolicyV1beta1APIResources.py
+++ b/actions/getPolicyV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getPolicyV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getPolicyV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getRbacAuthorizationAPIGroup.py
+++ b/actions/getRbacAuthorizationAPIGroup.py
@@ -13,13 +13,14 @@ class getRbacAuthorizationAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getRbacAuthorizationAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getRbacAuthorizationV1alpha1APIResources.py
+++ b/actions/getRbacAuthorizationV1alpha1APIResources.py
@@ -13,13 +13,14 @@ class getRbacAuthorizationV1alpha1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getRbacAuthorizationV1alpha1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getStorageAPIGroup.py
+++ b/actions/getStorageAPIGroup.py
@@ -13,13 +13,14 @@ class getStorageAPIGroup(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getStorageAPIGroup(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/getStorageV1beta1APIResources.py
+++ b/actions/getStorageV1beta1APIResources.py
@@ -13,13 +13,14 @@ class getStorageV1beta1APIResources(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json, application/yaml, application/vnd.kubernetes.protobuf', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/".format(  # noqa pylint: disable=line-too-long
             )
@@ -30,7 +31,10 @@ class getStorageV1beta1APIResources(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/lib/k8s.py
+++ b/actions/lib/k8s.py
@@ -29,6 +29,8 @@ class K8sClient(Action):
         else:
             self.req['data'] = ''
 
+        self.req['params'] = args.get('params', {})
+
         for entry in self.myconfig:
             if self.myconfig[entry] == 'None':
                 self.myconfig[entry] = None
@@ -82,5 +84,6 @@ class K8sClient(Action):
         kwargs['url'] = self.req['url']
         kwargs['json'] = self.req['data']
         kwargs['headers'] = self.req['headers']
+        kwargs['params'] = self.req['params']
         kwargs['verify'] = self.myconfig['verify']
         self.resp = getattr(s, self.req['method'])(**kwargs)

--- a/actions/listAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/listAppsV1beta1NamespacedStatefulSet.py
@@ -20,7 +20,7 @@ class listAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listAppsV1beta1StatefulSetForAllNamespaces.py
+++ b/actions/listAppsV1beta1StatefulSetForAllNamespaces.py
@@ -19,25 +19,26 @@ class listAppsV1beta1StatefulSetForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/statefulsets".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listAppsV1beta1StatefulSetForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces.py
+++ b/actions/listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces.py
@@ -19,25 +19,26 @@ class listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listAutoscalingV1HorizontalPodAutoscalerForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/listAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -20,7 +20,7 @@ class listAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listBatchV1JobForAllNamespaces.py
+++ b/actions/listBatchV1JobForAllNamespaces.py
@@ -19,25 +19,26 @@ class listBatchV1JobForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/jobs".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listBatchV1JobForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listBatchV1NamespacedJob.py
+++ b/actions/listBatchV1NamespacedJob.py
@@ -20,7 +20,7 @@ class listBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/listCertificatesV1alpha1CertificateSigningRequest.py
@@ -19,25 +19,26 @@ class listCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ComponentStatus.py
+++ b/actions/listCoreV1ComponentStatus.py
@@ -19,25 +19,26 @@ class listCoreV1ComponentStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/componentstatuses".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ComponentStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ConfigMapForAllNamespaces.py
+++ b/actions/listCoreV1ConfigMapForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1ConfigMapForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/configmaps".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ConfigMapForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1EndpointsForAllNamespaces.py
+++ b/actions/listCoreV1EndpointsForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1EndpointsForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/endpoints".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1EndpointsForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1EventForAllNamespaces.py
+++ b/actions/listCoreV1EventForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1EventForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/events".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1EventForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1LimitRangeForAllNamespaces.py
+++ b/actions/listCoreV1LimitRangeForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1LimitRangeForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/limitranges".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1LimitRangeForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1Namespace.py
+++ b/actions/listCoreV1Namespace.py
@@ -19,25 +19,26 @@ class listCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedConfigMap.py
+++ b/actions/listCoreV1NamespacedConfigMap.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedEndpoints.py
+++ b/actions/listCoreV1NamespacedEndpoints.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedEvent.py
+++ b/actions/listCoreV1NamespacedEvent.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedLimitRange.py
+++ b/actions/listCoreV1NamespacedLimitRange.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/listCoreV1NamespacedPersistentVolumeClaim.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedPod.py
+++ b/actions/listCoreV1NamespacedPod.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedPodTemplate.py
+++ b/actions/listCoreV1NamespacedPodTemplate.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedReplicationController.py
+++ b/actions/listCoreV1NamespacedReplicationController.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedResourceQuota.py
+++ b/actions/listCoreV1NamespacedResourceQuota.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedSecret.py
+++ b/actions/listCoreV1NamespacedSecret.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedService.py
+++ b/actions/listCoreV1NamespacedService.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1NamespacedServiceAccount.py
+++ b/actions/listCoreV1NamespacedServiceAccount.py
@@ -20,7 +20,7 @@ class listCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1Node.py
+++ b/actions/listCoreV1Node.py
@@ -19,25 +19,26 @@ class listCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1PersistentVolume.py
+++ b/actions/listCoreV1PersistentVolume.py
@@ -19,25 +19,26 @@ class listCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1PersistentVolumeClaimForAllNamespaces.py
+++ b/actions/listCoreV1PersistentVolumeClaimForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1PersistentVolumeClaimForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumeclaims".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1PersistentVolumeClaimForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1PodForAllNamespaces.py
+++ b/actions/listCoreV1PodForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1PodForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/pods".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1PodForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1PodTemplateForAllNamespaces.py
+++ b/actions/listCoreV1PodTemplateForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1PodTemplateForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/podtemplates".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1PodTemplateForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ReplicationControllerForAllNamespaces.py
+++ b/actions/listCoreV1ReplicationControllerForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1ReplicationControllerForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/replicationcontrollers".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ReplicationControllerForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ResourceQuotaForAllNamespaces.py
+++ b/actions/listCoreV1ResourceQuotaForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1ResourceQuotaForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/resourcequotas".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ResourceQuotaForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1SecretForAllNamespaces.py
+++ b/actions/listCoreV1SecretForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1SecretForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/secrets".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1SecretForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ServiceAccountForAllNamespaces.py
+++ b/actions/listCoreV1ServiceAccountForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1ServiceAccountForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/serviceaccounts".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ServiceAccountForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listCoreV1ServiceForAllNamespaces.py
+++ b/actions/listCoreV1ServiceForAllNamespaces.py
@@ -19,25 +19,26 @@ class listCoreV1ServiceForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/services".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listCoreV1ServiceForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1DaemonSetForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1DaemonSetForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1DaemonSetForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/daemonsets".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1DaemonSetForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1DeploymentForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1DeploymentForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1DeploymentForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/deployments".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1DeploymentForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1HorizontalPodAutoscalerForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1HorizontalPodAutoscalerForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1HorizontalPodAutoscalerForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1HorizontalPodAutoscalerForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1IngressForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1IngressForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1IngressForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/ingresses".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1IngressForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1JobForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1JobForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1JobForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/jobs".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1JobForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/listExtensionsV1beta1NamespacedDaemonSet.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/listExtensionsV1beta1NamespacedDeployment.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/listExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedIngress.py
+++ b/actions/listExtensionsV1beta1NamespacedIngress.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedJob.py
+++ b/actions/listExtensionsV1beta1NamespacedJob.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/listExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/listExtensionsV1beta1NamespacedReplicaSet.py
@@ -20,7 +20,7 @@ class listExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1NetworkPolicyForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1NetworkPolicyForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1NetworkPolicyForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/networkpolicies".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1NetworkPolicyForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1ReplicaSetForAllNamespaces.py
+++ b/actions/listExtensionsV1beta1ReplicaSetForAllNamespaces.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1ReplicaSetForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/replicasets".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1ReplicaSetForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/listExtensionsV1beta1ThirdPartyResource.py
@@ -19,25 +19,26 @@ class listExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listPolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/listPolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -20,7 +20,7 @@ class listPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listPolicyV1beta1PodDisruptionBudgetForAllNamespaces.py
+++ b/actions/listPolicyV1beta1PodDisruptionBudgetForAllNamespaces.py
@@ -19,25 +19,26 @@ class listPolicyV1beta1PodDisruptionBudgetForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/poddisruptionbudgets".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listPolicyV1beta1PodDisruptionBudgetForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/listRbacAuthorizationV1alpha1ClusterRole.py
@@ -19,25 +19,26 @@ class listRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/listRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -19,25 +19,26 @@ class listRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/listRbacAuthorizationV1alpha1NamespacedRole.py
@@ -20,7 +20,7 @@ class listRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/listRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -20,7 +20,7 @@ class listRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,19 +30,20 @@ class listRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings".format(  # noqa pylint: disable=line-too-long
             namespace=namespace)
@@ -53,7 +54,10 @@ class listRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1RoleBindingForAllNamespaces.py
+++ b/actions/listRbacAuthorizationV1alpha1RoleBindingForAllNamespaces.py
@@ -19,25 +19,26 @@ class listRbacAuthorizationV1alpha1RoleBindingForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/rolebindings".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listRbacAuthorizationV1alpha1RoleBindingForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listRbacAuthorizationV1alpha1RoleForAllNamespaces.py
+++ b/actions/listRbacAuthorizationV1alpha1RoleForAllNamespaces.py
@@ -19,25 +19,26 @@ class listRbacAuthorizationV1alpha1RoleForAllNamespaces(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/roles".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listRbacAuthorizationV1alpha1RoleForAllNamespaces(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/listStorageV1beta1StorageClass.py
+++ b/actions/listStorageV1beta1StorageClass.py
@@ -19,25 +19,26 @@ class listStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
 
         if fieldSelector is not None:
-            args['fieldSelector'] = fieldSelector
+            args['params'].update({'fieldSelector': fieldSelector})
         if labelSelector is not None:
-            args['labelSelector'] = labelSelector
+            args['params'].update({'labelSelector': labelSelector})
         if resourceVersion is not None:
-            args['resourceVersion'] = resourceVersion
+            args['params'].update({'resourceVersion': resourceVersion})
         if timeoutSeconds is not None:
-            args['timeoutSeconds'] = timeoutSeconds
+            args['params'].update({'timeoutSeconds': timeoutSeconds})
         if watch is not None:
-            args['watch'] = watch
+            args['params'].update({'watch': watch})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf, application/json;stream=watch, application/vnd.kubernetes.protobuf;stream=watch'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses".format(  # noqa pylint: disable=line-too-long
             )
@@ -48,7 +49,10 @@ class listStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/patchAppsV1beta1NamespacedStatefulSet.py
@@ -17,7 +17,7 @@ class patchAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchAppsV1beta1NamespacedStatefulSetStatus.py
+++ b/actions/patchAppsV1beta1NamespacedStatefulSetStatus.py
@@ -17,7 +17,7 @@ class patchAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/patchAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -17,7 +17,7 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
@@ -17,7 +17,7 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchBatchV1NamespacedJob.py
+++ b/actions/patchBatchV1NamespacedJob.py
@@ -17,7 +17,7 @@ class patchBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchBatchV1NamespacedJobStatus.py
+++ b/actions/patchBatchV1NamespacedJobStatus.py
@@ -17,7 +17,7 @@ class patchBatchV1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchBatchV1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchBatchV1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/patchCertificatesV1alpha1CertificateSigningRequest.py
@@ -16,7 +16,7 @@ class patchCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCertificatesV1alpha1CertificateSigningRequest(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1Namespace.py
+++ b/actions/patchCoreV1Namespace.py
@@ -16,7 +16,7 @@ class patchCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1Namespace(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespaceStatus.py
+++ b/actions/patchCoreV1NamespaceStatus.py
@@ -16,7 +16,7 @@ class patchCoreV1NamespaceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1NamespaceStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1NamespaceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedConfigMap.py
+++ b/actions/patchCoreV1NamespacedConfigMap.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedEndpoints.py
+++ b/actions/patchCoreV1NamespacedEndpoints.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedEvent.py
+++ b/actions/patchCoreV1NamespacedEvent.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedLimitRange.py
+++ b/actions/patchCoreV1NamespacedLimitRange.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/patchCoreV1NamespacedPersistentVolumeClaim.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedPersistentVolumeClaimStatus.py
+++ b/actions/patchCoreV1NamespacedPersistentVolumeClaimStatus.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedPod.py
+++ b/actions/patchCoreV1NamespacedPod.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedPodStatus.py
+++ b/actions/patchCoreV1NamespacedPodStatus.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedPodStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedPodStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedPodStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedPodTemplate.py
+++ b/actions/patchCoreV1NamespacedPodTemplate.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedReplicationController.py
+++ b/actions/patchCoreV1NamespacedReplicationController.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedReplicationControllerStatus.py
+++ b/actions/patchCoreV1NamespacedReplicationControllerStatus.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedReplicationControllerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedResourceQuota.py
+++ b/actions/patchCoreV1NamespacedResourceQuota.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedResourceQuotaStatus.py
+++ b/actions/patchCoreV1NamespacedResourceQuotaStatus.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedResourceQuotaStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedScaleScale.py
+++ b/actions/patchCoreV1NamespacedScaleScale.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedScaleScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedScaleScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedScaleScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedSecret.py
+++ b/actions/patchCoreV1NamespacedSecret.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedService.py
+++ b/actions/patchCoreV1NamespacedService.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedServiceAccount.py
+++ b/actions/patchCoreV1NamespacedServiceAccount.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NamespacedServiceStatus.py
+++ b/actions/patchCoreV1NamespacedServiceStatus.py
@@ -17,7 +17,7 @@ class patchCoreV1NamespacedServiceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchCoreV1NamespacedServiceStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchCoreV1NamespacedServiceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1Node.py
+++ b/actions/patchCoreV1Node.py
@@ -16,7 +16,7 @@ class patchCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1Node(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1NodeStatus.py
+++ b/actions/patchCoreV1NodeStatus.py
@@ -16,7 +16,7 @@ class patchCoreV1NodeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1NodeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1NodeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1PersistentVolume.py
+++ b/actions/patchCoreV1PersistentVolume.py
@@ -16,7 +16,7 @@ class patchCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1PersistentVolume(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchCoreV1PersistentVolumeStatus.py
+++ b/actions/patchCoreV1PersistentVolumeStatus.py
@@ -16,7 +16,7 @@ class patchCoreV1PersistentVolumeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchCoreV1PersistentVolumeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchCoreV1PersistentVolumeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/patchExtensionsV1beta1NamespacedDaemonSet.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedDaemonSetStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedDaemonSetStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/patchExtensionsV1beta1NamespacedDeployment.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedDeploymentStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedDeploymentStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedDeploymentsScale.py
+++ b/actions/patchExtensionsV1beta1NamespacedDeploymentsScale.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/patchExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedIngress.py
+++ b/actions/patchExtensionsV1beta1NamespacedIngress.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedIngressStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedIngressStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedIngressStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedJob.py
+++ b/actions/patchExtensionsV1beta1NamespacedJob.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedJobStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedJobStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/patchExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/patchExtensionsV1beta1NamespacedReplicaSet.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedReplicaSetStatus.py
+++ b/actions/patchExtensionsV1beta1NamespacedReplicaSetStatus.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedReplicasetsScale.py
+++ b/actions/patchExtensionsV1beta1NamespacedReplicasetsScale.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1NamespacedReplicationcontrollersScale.py
+++ b/actions/patchExtensionsV1beta1NamespacedReplicationcontrollersScale.py
@@ -17,7 +17,7 @@ class patchExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/patchExtensionsV1beta1ThirdPartyResource.py
@@ -16,7 +16,7 @@ class patchExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchExtensionsV1beta1ThirdPartyResource(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchPolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/patchPolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -17,7 +17,7 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
+++ b/actions/patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
@@ -17,7 +17,7 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/patchRbacAuthorizationV1alpha1ClusterRole.py
@@ -16,7 +16,7 @@ class patchRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchRbacAuthorizationV1alpha1ClusterRole(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/patchRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -16,7 +16,7 @@ class patchRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/patchRbacAuthorizationV1alpha1NamespacedRole.py
@@ -17,7 +17,7 @@ class patchRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/patchRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -17,7 +17,7 @@ class patchRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class patchRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class patchRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/patchStorageV1beta1StorageClass.py
+++ b/actions/patchStorageV1beta1StorageClass.py
@@ -16,7 +16,7 @@ class patchStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class patchStorageV1beta1StorageClass(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json-patch+json, application/merge-patch+json, application/strategic-merge-patch+json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class patchStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/readAppsV1beta1NamespacedStatefulSet.py
@@ -18,7 +18,7 @@ class readAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readAppsV1beta1NamespacedStatefulSetStatus.py
+++ b/actions/readAppsV1beta1NamespacedStatefulSetStatus.py
@@ -16,7 +16,7 @@ class readAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/readAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -18,7 +18,7 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
@@ -16,7 +16,7 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readBatchV1NamespacedJob.py
+++ b/actions/readBatchV1NamespacedJob.py
@@ -18,7 +18,7 @@ class readBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readBatchV1NamespacedJobStatus.py
+++ b/actions/readBatchV1NamespacedJobStatus.py
@@ -16,7 +16,7 @@ class readBatchV1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readBatchV1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readBatchV1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/readCertificatesV1alpha1CertificateSigningRequest.py
@@ -17,7 +17,7 @@ class readCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readCertificatesV1alpha1CertificateSigningRequest(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1ComponentStatus.py
+++ b/actions/readCoreV1ComponentStatus.py
@@ -15,7 +15,7 @@ class readCoreV1ComponentStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readCoreV1ComponentStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/componentstatuses/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readCoreV1ComponentStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1Namespace.py
+++ b/actions/readCoreV1Namespace.py
@@ -17,7 +17,7 @@ class readCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readCoreV1Namespace(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespaceStatus.py
+++ b/actions/readCoreV1NamespaceStatus.py
@@ -15,7 +15,7 @@ class readCoreV1NamespaceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readCoreV1NamespaceStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readCoreV1NamespaceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedConfigMap.py
+++ b/actions/readCoreV1NamespacedConfigMap.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedEndpoints.py
+++ b/actions/readCoreV1NamespacedEndpoints.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedEvent.py
+++ b/actions/readCoreV1NamespacedEvent.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedLimitRange.py
+++ b/actions/readCoreV1NamespacedLimitRange.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/readCoreV1NamespacedPersistentVolumeClaim.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPersistentVolumeClaimStatus.py
+++ b/actions/readCoreV1NamespacedPersistentVolumeClaimStatus.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPod.py
+++ b/actions/readCoreV1NamespacedPod.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPodLog.py
+++ b/actions/readCoreV1NamespacedPodLog.py
@@ -24,7 +24,7 @@ class readCoreV1NamespacedPodLog(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -38,25 +38,26 @@ class readCoreV1NamespacedPodLog(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if container is not None:
-            args['container'] = container
+            args['params'].update({'container': container})
         if follow is not None:
-            args['follow'] = follow
+            args['params'].update({'follow': follow})
         if limitBytes is not None:
-            args['limitBytes'] = limitBytes
+            args['params'].update({'limitBytes': limitBytes})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if previous is not None:
-            args['previous'] = previous
+            args['params'].update({'previous': previous})
         if sinceSeconds is not None:
-            args['sinceSeconds'] = sinceSeconds
+            args['params'].update({'sinceSeconds': sinceSeconds})
         if sinceTime is not None:
-            args['sinceTime'] = sinceTime
+            args['params'].update({'sinceTime': sinceTime})
         if tailLines is not None:
-            args['tailLines'] = tailLines
+            args['params'].update({'tailLines': tailLines})
         if timestamps is not None:
-            args['timestamps'] = timestamps
+            args['params'].update({'timestamps': timestamps})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'text/plain, application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/log".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -67,7 +68,10 @@ class readCoreV1NamespacedPodLog(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPodStatus.py
+++ b/actions/readCoreV1NamespacedPodStatus.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedPodStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedPodStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedPodStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedPodTemplate.py
+++ b/actions/readCoreV1NamespacedPodTemplate.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedReplicationController.py
+++ b/actions/readCoreV1NamespacedReplicationController.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedReplicationControllerStatus.py
+++ b/actions/readCoreV1NamespacedReplicationControllerStatus.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedReplicationControllerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedResourceQuota.py
+++ b/actions/readCoreV1NamespacedResourceQuota.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedResourceQuotaStatus.py
+++ b/actions/readCoreV1NamespacedResourceQuotaStatus.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedResourceQuotaStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedScaleScale.py
+++ b/actions/readCoreV1NamespacedScaleScale.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedScaleScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedScaleScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedScaleScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedSecret.py
+++ b/actions/readCoreV1NamespacedSecret.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedService.py
+++ b/actions/readCoreV1NamespacedService.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedServiceAccount.py
+++ b/actions/readCoreV1NamespacedServiceAccount.py
@@ -18,7 +18,7 @@ class readCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NamespacedServiceStatus.py
+++ b/actions/readCoreV1NamespacedServiceStatus.py
@@ -16,7 +16,7 @@ class readCoreV1NamespacedServiceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readCoreV1NamespacedServiceStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readCoreV1NamespacedServiceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1Node.py
+++ b/actions/readCoreV1Node.py
@@ -17,7 +17,7 @@ class readCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readCoreV1Node(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1NodeStatus.py
+++ b/actions/readCoreV1NodeStatus.py
@@ -15,7 +15,7 @@ class readCoreV1NodeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readCoreV1NodeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readCoreV1NodeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1PersistentVolume.py
+++ b/actions/readCoreV1PersistentVolume.py
@@ -17,7 +17,7 @@ class readCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readCoreV1PersistentVolume(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readCoreV1PersistentVolumeStatus.py
+++ b/actions/readCoreV1PersistentVolumeStatus.py
@@ -15,7 +15,7 @@ class readCoreV1PersistentVolumeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readCoreV1PersistentVolumeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readCoreV1PersistentVolumeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/readExtensionsV1beta1NamespacedDaemonSet.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedDaemonSetStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedDaemonSetStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/readExtensionsV1beta1NamespacedDeployment.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedDeploymentStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedDeploymentStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedDeploymentsScale.py
+++ b/actions/readExtensionsV1beta1NamespacedDeploymentsScale.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/readExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedIngress.py
+++ b/actions/readExtensionsV1beta1NamespacedIngress.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedIngressStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedIngressStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedIngressStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedJob.py
+++ b/actions/readExtensionsV1beta1NamespacedJob.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedJobStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedJobStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/readExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/readExtensionsV1beta1NamespacedReplicaSet.py
@@ -18,7 +18,7 @@ class readExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedReplicaSetStatus.py
+++ b/actions/readExtensionsV1beta1NamespacedReplicaSetStatus.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedReplicasetsScale.py
+++ b/actions/readExtensionsV1beta1NamespacedReplicasetsScale.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1NamespacedReplicationcontrollersScale.py
+++ b/actions/readExtensionsV1beta1NamespacedReplicationcontrollersScale.py
@@ -16,7 +16,7 @@ class readExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/readExtensionsV1beta1ThirdPartyResource.py
@@ -17,7 +17,7 @@ class readExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readExtensionsV1beta1ThirdPartyResource(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readPolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/readPolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -18,7 +18,7 @@ class readPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,13 +32,14 @@ class readPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -49,7 +50,10 @@ class readPolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readPolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
+++ b/actions/readPolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
@@ -16,7 +16,7 @@ class readPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readPolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/readRbacAuthorizationV1alpha1ClusterRole.py
@@ -15,7 +15,7 @@ class readRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readRbacAuthorizationV1alpha1ClusterRole(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/readRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -15,7 +15,7 @@ class readRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -25,9 +25,10 @@ class readRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -38,7 +39,10 @@ class readRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/readRbacAuthorizationV1alpha1NamespacedRole.py
@@ -16,7 +16,7 @@ class readRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/readRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -16,7 +16,7 @@ class readRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class readRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             name=name, namespace=namespace)
@@ -43,7 +44,10 @@ class readRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/readStorageV1beta1StorageClass.py
+++ b/actions/readStorageV1beta1StorageClass.py
@@ -17,7 +17,7 @@ class readStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -27,13 +27,14 @@ class readStorageV1beta1StorageClass(K8sClient):
         else:
             return (False, "name is a required parameter")
         if exact is not None:
-            args['exact'] = exact
+            args['params'].update({'exact': exact})
         if export is not None:
-            args['export'] = export
+            args['params'].update({'export': export})
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses/{name}".format(  # noqa pylint: disable=line-too-long
             name=name)
@@ -44,7 +45,10 @@ class readStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceAppsV1beta1NamespacedStatefulSet.py
+++ b/actions/replaceAppsV1beta1NamespacedStatefulSet.py
@@ -17,7 +17,7 @@ class replaceAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceAppsV1beta1NamespacedStatefulSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceAppsV1beta1NamespacedStatefulSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceAppsV1beta1NamespacedStatefulSetStatus.py
+++ b/actions/replaceAppsV1beta1NamespacedStatefulSetStatus.py
@@ -17,7 +17,7 @@ class replaceAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/apps/v1beta1/namespaces/{namespace}/statefulsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceAppsV1beta1NamespacedStatefulSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceAutoscalingV1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/replaceAutoscalingV1NamespacedHorizontalPodAutoscaler.py
@@ -17,7 +17,7 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus.py
@@ -17,7 +17,7 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/autoscaling/v1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceAutoscalingV1NamespacedHorizontalPodAutoscalerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceBatchV1NamespacedJob.py
+++ b/actions/replaceBatchV1NamespacedJob.py
@@ -17,7 +17,7 @@ class replaceBatchV1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceBatchV1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceBatchV1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceBatchV1NamespacedJobStatus.py
+++ b/actions/replaceBatchV1NamespacedJobStatus.py
@@ -17,7 +17,7 @@ class replaceBatchV1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceBatchV1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/batch/v1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceBatchV1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCertificatesV1alpha1CertificateSigningRequest.py
+++ b/actions/replaceCertificatesV1alpha1CertificateSigningRequest.py
@@ -16,7 +16,7 @@ class replaceCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequest(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequest(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCertificatesV1alpha1CertificateSigningRequestApproval.py
+++ b/actions/replaceCertificatesV1alpha1CertificateSigningRequestApproval.py
@@ -16,7 +16,7 @@ class replaceCertificatesV1alpha1CertificateSigningRequestApproval(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequestApproval(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/approval".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequestApproval(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCertificatesV1alpha1CertificateSigningRequestStatus.py
+++ b/actions/replaceCertificatesV1alpha1CertificateSigningRequestStatus.py
@@ -16,7 +16,7 @@ class replaceCertificatesV1alpha1CertificateSigningRequestStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequestStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/certificates.k8s.io/v1alpha1/certificatesigningrequests/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCertificatesV1alpha1CertificateSigningRequestStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1Namespace.py
+++ b/actions/replaceCoreV1Namespace.py
@@ -16,7 +16,7 @@ class replaceCoreV1Namespace(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1Namespace(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1Namespace(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespaceFinalize.py
+++ b/actions/replaceCoreV1NamespaceFinalize.py
@@ -16,7 +16,7 @@ class replaceCoreV1NamespaceFinalize(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1NamespaceFinalize(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}/finalize".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1NamespaceFinalize(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespaceStatus.py
+++ b/actions/replaceCoreV1NamespaceStatus.py
@@ -16,7 +16,7 @@ class replaceCoreV1NamespaceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1NamespaceStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1NamespaceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedConfigMap.py
+++ b/actions/replaceCoreV1NamespacedConfigMap.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedConfigMap(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedConfigMap(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/configmaps/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedConfigMap(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedEndpoints.py
+++ b/actions/replaceCoreV1NamespacedEndpoints.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedEndpoints(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedEndpoints(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/endpoints/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedEndpoints(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedEvent.py
+++ b/actions/replaceCoreV1NamespacedEvent.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedEvent(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedEvent(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/events/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedEvent(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedLimitRange.py
+++ b/actions/replaceCoreV1NamespacedLimitRange.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedLimitRange(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedLimitRange(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/limitranges/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedLimitRange(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedPersistentVolumeClaim.py
+++ b/actions/replaceCoreV1NamespacedPersistentVolumeClaim.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedPersistentVolumeClaim(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedPersistentVolumeClaim(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedPersistentVolumeClaimStatus.py
+++ b/actions/replaceCoreV1NamespacedPersistentVolumeClaimStatus.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/persistentvolumeclaims/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedPersistentVolumeClaimStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedPod.py
+++ b/actions/replaceCoreV1NamespacedPod.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedPod(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedPod(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedPod(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedPodStatus.py
+++ b/actions/replaceCoreV1NamespacedPodStatus.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedPodStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedPodStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/pods/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedPodStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedPodTemplate.py
+++ b/actions/replaceCoreV1NamespacedPodTemplate.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedPodTemplate(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedPodTemplate(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/podtemplates/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedPodTemplate(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedReplicationController.py
+++ b/actions/replaceCoreV1NamespacedReplicationController.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedReplicationController(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedReplicationController(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedReplicationController(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedReplicationControllerStatus.py
+++ b/actions/replaceCoreV1NamespacedReplicationControllerStatus.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedReplicationControllerStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedReplicationControllerStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedResourceQuota.py
+++ b/actions/replaceCoreV1NamespacedResourceQuota.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedResourceQuota(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedResourceQuota(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedResourceQuota(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedResourceQuotaStatus.py
+++ b/actions/replaceCoreV1NamespacedResourceQuotaStatus.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedResourceQuotaStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/resourcequotas/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedResourceQuotaStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedScaleScale.py
+++ b/actions/replaceCoreV1NamespacedScaleScale.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedScaleScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedScaleScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedScaleScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedSecret.py
+++ b/actions/replaceCoreV1NamespacedSecret.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedSecret(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedSecret(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/secrets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedSecret(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedService.py
+++ b/actions/replaceCoreV1NamespacedService.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedService(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedService(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedService(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedServiceAccount.py
+++ b/actions/replaceCoreV1NamespacedServiceAccount.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedServiceAccount(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedServiceAccount(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/serviceaccounts/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedServiceAccount(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NamespacedServiceStatus.py
+++ b/actions/replaceCoreV1NamespacedServiceStatus.py
@@ -17,7 +17,7 @@ class replaceCoreV1NamespacedServiceStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceCoreV1NamespacedServiceStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/namespaces/{namespace}/services/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceCoreV1NamespacedServiceStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1Node.py
+++ b/actions/replaceCoreV1Node.py
@@ -16,7 +16,7 @@ class replaceCoreV1Node(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1Node(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1Node(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1NodeStatus.py
+++ b/actions/replaceCoreV1NodeStatus.py
@@ -16,7 +16,7 @@ class replaceCoreV1NodeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1NodeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/nodes/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1NodeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1PersistentVolume.py
+++ b/actions/replaceCoreV1PersistentVolume.py
@@ -16,7 +16,7 @@ class replaceCoreV1PersistentVolume(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1PersistentVolume(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1PersistentVolume(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceCoreV1PersistentVolumeStatus.py
+++ b/actions/replaceCoreV1PersistentVolumeStatus.py
@@ -16,7 +16,7 @@ class replaceCoreV1PersistentVolumeStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceCoreV1PersistentVolumeStatus(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "api/v1/persistentvolumes/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceCoreV1PersistentVolumeStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedDaemonSet.py
+++ b/actions/replaceExtensionsV1beta1NamespacedDaemonSet.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedDaemonSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedDaemonSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedDaemonSetStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedDaemonSetStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/daemonsets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedDaemonSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedDeployment.py
+++ b/actions/replaceExtensionsV1beta1NamespacedDeployment.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedDeployment(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedDeployment(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedDeploymentStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedDeploymentStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedDeploymentStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedDeploymentsScale.py
+++ b/actions/replaceExtensionsV1beta1NamespacedDeploymentsScale.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/deployments/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedDeploymentsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
+++ b/actions/replaceExtensionsV1beta1NamespacedHorizontalPodAutoscaler.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscaler(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient)
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient)
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedHorizontalPodAutoscalerStatus(K8sClient)
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedIngress.py
+++ b/actions/replaceExtensionsV1beta1NamespacedIngress.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedIngress(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedIngress(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedIngress(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedIngressStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedIngressStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedIngressStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/ingresses/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedIngressStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedJob.py
+++ b/actions/replaceExtensionsV1beta1NamespacedJob.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedJob(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedJob(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedJob(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedJobStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedJobStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedJobStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/jobs/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedJobStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedNetworkPolicy.py
+++ b/actions/replaceExtensionsV1beta1NamespacedNetworkPolicy.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/networkpolicies/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedNetworkPolicy(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedReplicaSet.py
+++ b/actions/replaceExtensionsV1beta1NamespacedReplicaSet.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedReplicaSet(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedReplicaSet(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedReplicaSetStatus.py
+++ b/actions/replaceExtensionsV1beta1NamespacedReplicaSetStatus.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedReplicaSetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedReplicasetsScale.py
+++ b/actions/replaceExtensionsV1beta1NamespacedReplicasetsScale.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicasets/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedReplicasetsScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1NamespacedReplicationcontrollersScale.py
+++ b/actions/replaceExtensionsV1beta1NamespacedReplicationcontrollersScale.py
@@ -17,7 +17,7 @@ class replaceExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/namespaces/{namespace}/replicationcontrollers/{name}/scale".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceExtensionsV1beta1NamespacedReplicationcontrollersScale(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceExtensionsV1beta1ThirdPartyResource.py
+++ b/actions/replaceExtensionsV1beta1ThirdPartyResource.py
@@ -16,7 +16,7 @@ class replaceExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceExtensionsV1beta1ThirdPartyResource(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/extensions/v1beta1/thirdpartyresources/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceExtensionsV1beta1ThirdPartyResource(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replacePolicyV1beta1NamespacedPodDisruptionBudget.py
+++ b/actions/replacePolicyV1beta1NamespacedPodDisruptionBudget.py
@@ -17,7 +17,7 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudget(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
+++ b/actions/replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus.py
@@ -17,7 +17,7 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/policy/v1beta1/namespaces/{namespace}/poddisruptionbudgets/{name}/status".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replacePolicyV1beta1NamespacedPodDisruptionBudgetStatus(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceRbacAuthorizationV1alpha1ClusterRole.py
+++ b/actions/replaceRbacAuthorizationV1alpha1ClusterRole.py
@@ -16,7 +16,7 @@ class replaceRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceRbacAuthorizationV1alpha1ClusterRole(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterroles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceRbacAuthorizationV1alpha1ClusterRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceRbacAuthorizationV1alpha1ClusterRoleBinding.py
+++ b/actions/replaceRbacAuthorizationV1alpha1ClusterRoleBinding.py
@@ -16,7 +16,7 @@ class replaceRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/clusterrolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceRbacAuthorizationV1alpha1ClusterRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceRbacAuthorizationV1alpha1NamespacedRole.py
+++ b/actions/replaceRbacAuthorizationV1alpha1NamespacedRole.py
@@ -17,7 +17,7 @@ class replaceRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/roles/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceRbacAuthorizationV1alpha1NamespacedRole(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceRbacAuthorizationV1alpha1NamespacedRoleBinding.py
+++ b/actions/replaceRbacAuthorizationV1alpha1NamespacedRoleBinding.py
@@ -17,7 +17,7 @@ class replaceRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -35,9 +35,10 @@ class replaceRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
         else:
             return (False, "namespace is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/rbac.authorization.k8s.io/v1alpha1/namespaces/{namespace}/rolebindings/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name, namespace=namespace)
@@ -48,7 +49,10 @@ class replaceRbacAuthorizationV1alpha1NamespacedRoleBinding(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/actions/replaceStorageV1beta1StorageClass.py
+++ b/actions/replaceStorageV1beta1StorageClass.py
@@ -16,7 +16,7 @@ class replaceStorageV1beta1StorageClass(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -30,9 +30,10 @@ class replaceStorageV1beta1StorageClass(K8sClient):
         else:
             return (False, "name is a required parameter")
         if pretty is not None:
-            args['pretty'] = pretty
+            args['params'].update({'pretty': pretty})
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {'Content-type': u'application/json', 'Accept': u'application/json, application/yaml, application/vnd.kubernetes.protobuf'}  # noqa pylint: disable=line-too-long
         args['url'] = "apis/storage.k8s.io/v1beta1/storageclasses/{name}".format(  # noqa pylint: disable=line-too-long
             body=body, name=name)
@@ -43,7 +44,10 @@ class replaceStorageV1beta1StorageClass(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/etc/st2packgen/files/actions/lib/k8s.py
+++ b/etc/st2packgen/files/actions/lib/k8s.py
@@ -29,6 +29,8 @@ class K8sClient(Action):
         else:
             self.req['data'] = ''
 
+        self.req['params'] = args.get('params', {})
+
         for entry in self.myconfig:
             if self.myconfig[entry] == 'None':
                 self.myconfig[entry] = None
@@ -82,5 +84,6 @@ class K8sClient(Action):
         kwargs['url'] = self.req['url']
         kwargs['json'] = self.req['data']
         kwargs['headers'] = self.req['headers']
+        kwargs['params'] = self.req['params']
         kwargs['verify'] = self.myconfig['verify']
         self.resp = getattr(s, self.req['method'])(**kwargs)

--- a/etc/st2packgen/templates/action_template.py.jinja
+++ b/etc/st2packgen/templates/action_template.py.jinja
@@ -19,7 +19,7 @@ class {{ operationId }}(K8sClient):
 
         args = {}
         args['config_override'] = {}
-        args['pretty'] = ''
+        args['params'] = {}
 
         if config_override is not None:
             args['config_override'] = config_override
@@ -32,11 +32,12 @@ class {{ operationId }}(K8sClient):
         {% endfor -%}
         {%- for p in params -%}
         if {{ p.name }} is not None:
-            args['{{ p.name }}'] = {{ p.name }}
+            args['params'].update({'{{ p.name }}': {{ p.name }}})
         {% endfor -%}
 
         if 'body' in args:
             args['data'] = args['body']
+            args.pop('body')
         args['headers'] = {{ headers }}  # noqa pylint: disable=line-too-long
         args['url'] = "{{ url }}".format(  # noqa pylint: disable=line-too-long
             {% for p in paramsreq -%}{{ p.name }}={{ p.name }}{{ ", " if not loop.last }}{% endfor -%})

--- a/etc/st2packgen/templates/action_template.py.jinja
+++ b/etc/st2packgen/templates/action_template.py.jinja
@@ -48,7 +48,10 @@ class {{ operationId }}(K8sClient):
 
         myresp = {}
         myresp['status_code'] = self.resp.status_code
-        myresp['data'] = json.loads(self.resp.content.rstrip())
+        try:
+            myresp['data'] = json.loads(self.resp.content.rstrip())
+        except ValueError:
+            myresp['data'] = self.resp.content
 
         if myresp['status_code'] >= 200 and myresp['status_code'] <= 299:
             ret = True

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - kubernetes
   - sensors
   - thirdpartyresource
-version: 0.9.11
+version: 0.9.12
 python_versions:
   - "2"
   - "3"


### PR DESCRIPTION
This introduces a mechanism for resolving the query parameters stored in the
args dictionary in all actions. These optional parameters were previously not
passed along with the API request in the K8sClient and were not resolved.
The Jinja template for the action script files has been modified to include
a params dictionary within the args holding the query parameters key-value
pairs. The k8s base client now consumes the params dictionary and passes it
as data for the URL query string upon making the request to the API.
All actions have been regenerated to reflect the changes in the template.