### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+* Removed Backport ssl in favor of built in ssl.
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - kubernetes
   - sensors
   - thirdpartyresource
-version: 1.0.0
+version: 1.0.1
 python_versions:
   - "3"
 author: Andrew Moore

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 pyswagger
 jinja2
 http_parser
-backports.ssl==0.0.9
-pyopenssl==17.5.0
-
+requests

--- a/sensors/sensor_base.py
+++ b/sensors/sensor_base.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from http_parser.pyparser import HttpParser
 
-from backports import ssl
+import ssl
 from st2reactor.sensor.base import Sensor
 
 
@@ -80,13 +80,16 @@ class SensorBase(Sensor):
 
         while True:
             try:
+                context = ssl.create_default_context()
                 self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 if self.authmethod == "basic":
-                    self.client = ssl.wrap_socket(self.sock)
+                    self.client = context.wrap_socket(self.sock)
                 elif self.authmethod == "cert":
-                    self.client = ssl.wrap_socket(self.sock,
-                                                  keyfile=self.config['client_cert_key_path'],
-                                                  certfile=self.config['client_cert_path'])
+                    context.load_cert_chain(
+                        certfile=self.config['client_cert_path'],
+                        keyfile=self.config['client_cert_key_path']
+                    )
+                    self.client = context.wrap_socket(self.sock)
                 else:
                     raise KeyError('No authentication mechanisms defined')
                 self._log.debug('Connecting to %s %i' % (self.host, self.port))


### PR DESCRIPTION
Backport ssl was used so that the ssl socket could be wrapped using the python 3.4 ssl implementation for use in a python 2.7 environment.

Since we have removed all of the python 2.7 implementations i converted it to the standard Python ssl implementation.